### PR TITLE
Add standalone tests for core scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "margotai",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "margotai",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "margotai",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/cookie-consent.test.js
+++ b/tests/cookie-consent.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('cookie consent stores choice and hides banner', () => {
+  const elements = {};
+  const banner = {
+    hidden: true,
+    setAttribute(attr) { if(attr === 'hidden') this.hidden = true; },
+    removeAttribute(attr) { if(attr === 'hidden') this.hidden = false; }
+  };
+  elements['cookieBanner'] = banner;
+  function button(id) {
+    elements[id] = {
+      handler: null,
+      addEventListener(ev, fn) { if(ev === 'click') this.handler = fn; },
+      click() { this.handler && this.handler(); }
+    };
+  }
+  button('acceptAllCookies');
+  button('rejectAllCookies');
+  button('acceptNecessaryCookies');
+
+  global.document = { getElementById: id => elements[id] };
+
+  const store = {};
+  global.localStorage = {
+    getItem: k => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); }
+  };
+
+  require('../cookie-consent.js');
+
+  assert.strictEqual(banner.hidden, false);
+
+  elements['acceptAllCookies'].click();
+  assert.strictEqual(store['cookie-consent'], 'all');
+  assert.strictEqual(banner.hidden, true);
+});

--- a/tests/order-collector.test.js
+++ b/tests/order-collector.test.js
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('order-collector posts sanitized data', () => {
+  const elements = {};
+  function input(id, value) {
+    elements[id] = { value, addEventListener: () => {} };
+  }
+  function button(id) {
+    elements[id] = {
+      handlers: {},
+      addEventListener(ev, fn) { this.handlers[ev] = fn; },
+      click() { this.handlers['click'] && this.handlers['click'](); }
+    };
+  }
+  input('firstName', ' John ');
+  input('lastName', ' Doe ');
+  input('idNumber', ' 123 ');
+  input('phone', ' 555 ');
+  input('email', ' TEST@Example.com ');
+  input('address', ' Main St ');
+  button('confirmBtn');
+
+  global.document = { getElementById: id => elements[id] };
+
+  const workerMessages = [];
+  class FakeWorker {
+    constructor() { this.messages = workerMessages; }
+    postMessage(msg) { this.messages.push(msg); }
+    addEventListener() {}
+  }
+  global.Worker = FakeWorker;
+
+  global.window = {
+    deliveryMinutes: 30,
+    lang: 'en',
+    cart: new Map([['p1', 2]]),
+    PRODUCTS: [{ id: 'p1', name_en: 'Widget', name_es: 'Artilugio', price: 5 }],
+    totals: () => ({ total: 10 })
+  };
+
+  require('../order-collector.js');
+
+  elements['confirmBtn'].click();
+
+  assert.deepStrictEqual(workerMessages[0], {
+    customer: {
+      firstName: 'John',
+      lastName: 'Doe',
+      idNumber: '123',
+      phone: '555',
+      email: 'test@example.com',
+      address: 'Main St'
+    },
+    order: {
+      items: [{ id: 'p1', name: 'Widget', qty: 2, price: 5 }],
+      totals: { total: 10 },
+      deliveryMinutes: 30
+    }
+  });
+});

--- a/tests/order-worker.test.js
+++ b/tests/order-worker.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+test('order worker posts payload to API', async () => {
+  const logs = {};
+  const context = {
+    fetch: async (url, opts) => { logs.url = url; logs.opts = opts; },
+    CONFIG: { CLOUDFLARE_WORKER_URL: '', APPS_SCRIPT_URL: '' },
+    console,
+    self: {}
+  };
+  context.self.location = { origin: 'https://example.com' };
+  context.self.importScripts = () => {};
+  context.self.postMessage = msg => { logs.msg = msg; };
+  context.self.addEventListener = (event, handler) => { context.onMessage = handler; };
+
+  vm.createContext(context);
+  const code = fs.readFileSync(path.join(__dirname, '..', 'order-worker.js'), 'utf8');
+  vm.runInContext(code, context);
+
+  await context.onMessage({ data: { hello: 'world' } });
+
+  assert.strictEqual(logs.url, 'https://example.com/api/order');
+  assert.strictEqual(logs.opts.method, 'POST');
+  assert.deepStrictEqual(JSON.parse(logs.opts.body), { hello: 'world' });
+  assert.strictEqual(logs.msg && logs.msg.ok, true);
+});


### PR DESCRIPTION
## Summary
- add `node --test` setup
- cover order collection, cookie consent, and worker posting logic with isolated tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5f7b3e18c832b9d7c1b20284544cf