### PR TITLE
Fix cookie consent buttons to close banner

### DIFF
--- a/cookie-consent.js
+++ b/cookie-consent.js
@@ -12,9 +12,9 @@
       localStorage.setItem('cookie-consent',value);
       banner.remove();
     }
-    acceptAll.addEventListener('click',()=>setConsent('all'));
-    rejectAll.addEventListener('click',()=>setConsent('none'));
-    acceptNecessary.addEventListener('click',()=>setConsent('necessary'));
+    acceptAll.addEventListener('click',ev=>{ev?.preventDefault();setConsent('all');});
+    rejectAll.addEventListener('click',ev=>{ev?.preventDefault();setConsent('none');});
+    acceptNecessary.addEventListener('click',ev=>{ev?.preventDefault();setConsent('necessary');});
   }
   if(document.readyState==='loading'){
     document.addEventListener('DOMContentLoaded',init);

--- a/index.html
+++ b/index.html
@@ -358,7 +358,7 @@
 
   <script nonce="2726c7f26c" src="config.js" integrity="sha384-Pet/KlYr4A5NXXhYEt/VB5cvYTny7+J2AIhlu680LQB2T8WcMAOhn5mzo6mChFE9" crossorigin="anonymous" data-check></script>
   <script nonce="2726c7f26c" src="sw-register.js" integrity="sha384-F+61rrWkZLGuA6IQnoj0ep3wkTPooICNzyW9K5U0sdkpveXUjiEgsDmbSsQGV+4X" crossorigin="anonymous" data-check></script>
-  <script nonce="2726c7f26c" src="cookie-consent.js" integrity="sha384-n343j8tMrmGKeoysfh9kQa5csMDvucOv7yhPIs4t9UGndp7aVuEzAyC9mxV8EZS8" crossorigin="anonymous" data-check></script>
+  <script nonce="2726c7f26c" src="cookie-consent.js" integrity="sha384-uYbPSRY0EDtc2fPaYTinOSGjZjHbIzMs4BmGA/a306kjX8kjlV5OwHxNgVfzGgTj" crossorigin="anonymous" data-check></script>
   <script nonce="2726c7f26c">
     /* CONFIG */
     const {CLOUDFLARE_WORKER_URL, APPS_SCRIPT_URL, WHATSAPP_NUMBER} = CONFIG;
@@ -653,9 +653,9 @@
   <div id="cookieBanner" class="cookie-banner" hidden>
     <p>We use cookies to improve your experience.</p>
     <div class="cookie-actions">
-      <button id="acceptAllCookies">Accept All</button>
-      <button id="rejectAllCookies">Reject All</button>
-      <button id="acceptNecessaryCookies">Accept Necessary</button>
+      <button type="button" id="acceptAllCookies">Accept All</button>
+      <button type="button" id="rejectAllCookies">Reject All</button>
+      <button type="button" id="acceptNecessaryCookies">Accept Necessary</button>
     </div>
   </div>
   <script nonce="2726c7f26c" src="order-collector.js" integrity="sha384-qAmIuVt/AYOF9E04H5d35lpDculHPrKKccwRc8tXOEMVtqFTmQ40XSowFtgUjb45" crossorigin="anonymous" data-check></script>


### PR DESCRIPTION
## Summary
- Prevent default form submission and hide banner when cookie consent buttons are clicked
- Mark cookie consent buttons as non-submitting buttons and refresh SRI hash

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6068cfdc0832b9cfafdf863ae4ca7